### PR TITLE
[#10] Add mixed-integer LP DSL support

### DIFF
--- a/docs/dataframe-dsl-design.md
+++ b/docs/dataframe-dsl-design.md
@@ -23,9 +23,11 @@ This removes the need for callers to hand-build slack columns or to keep the pos
 ## Non-goals for the first release
 
 - Replacing the numerical solver or its `LP.solve(c, AT, b)` API.
-- Mixed-integer optimisation. The API reserves `category`, but only `Continuous` is accepted in the first release.
 - Claiming that arbitrary, infeasible, or rank-deficient LPs can be solved. Existing solver preconditions remain explicit.
 - Making a driver-sized right-hand-side vector disappear. The present solver uses a local `DenseVector` for `b`; the compiler must reject a model whose constraint rows cannot safely be collected on the driver.
+
+Mixed-integer optimisation is part of the DSL: `Integer` and `Binary` are ordinary variable
+categories and `solve()` chooses the appropriate internal solve path automatically.
 
 ## Public API
 
@@ -46,8 +48,8 @@ case object Maximize extends ObjectiveSense
 
 sealed trait VariableCategory
 case object Continuous extends VariableCategory
-case object Integer extends VariableCategory // reserved; rejected in v1
-case object Binary extends VariableCategory  // reserved; rejected in v1
+case object Integer extends VariableCategory // integral values within declared finite bounds
+case object Binary extends VariableCategory  // domain {0,1} ∩ declared bounds
 
 sealed trait LpStatus
 object LpStatus {
@@ -349,7 +351,7 @@ Validation happens during `solve`, after Spark has materialised the lightweight 
 - missing or duplicate RHS rows for a bulk constraint group, or a zero-term group row with a non-zero RHS;
 - `lowerBound > upperBound`;
 - a finite `upperBound` combined with `lowerBound = -inf` (rejected in v1: the free-variable split has no single shifted variable to bound; support for `x <= u` alone can be added later as `u - x >= 0`);
-- unsupported integer/binary categories;
+- an `Integer` variable without finite bounds, or integral bounds enclosing no integer;
 - an empty model (no constraints), which `Initialize.init` already rejects;
 - duplicate coefficient rows: merged when the RHS also matches, an `LpModelException` naming both constraints when it does not (see "Open decisions — resolved"); and
 - more than `maxLocalConstraints` expanded rows. General rank deficiency (beyond exact duplicates) is *not* validated up front: it surfaces when Cholesky fails and is reported as `LpNumericalException` naming the full-row-rank precondition.
@@ -360,6 +362,16 @@ Infeasibility and unboundedness are detected through Farkas certificates, never 
 - **Dual infeasibility** — a ray `z = x / |c^T x|` with `z >= 0`, `c^T z = -1`, and `‖A z‖_∞ / |c^T x| <= ε_inf` proves that the dual is infeasible, i.e. the primal is unbounded *if* it is feasible at all.
 
 `ε_inf` is `SolveConfig.infeasibilityTolerance` (default `1e-8`); setting it to a negative value disables detection. The DSL maps the solver's terminations to statuses as follows: a primal certificate is always `Infeasible`; a dual certificate is `Unbounded` when the final iterate is primal-feasible within `SolveConfig.tolerance` (a feasible point plus an unbounded ray is conclusive) and `InfeasibleOrUnbounded` otherwise, because a dual certificate alone genuinely cannot distinguish the two cases. `objectiveValue` is `NaN` at `Infeasible` and `InfeasibleOrUnbounded`, and the signed infinity matching the objective sense at `Unbounded` (`+inf` for `Maximize`, `-inf` for `Minimize`). The same certificate test runs on the last successful iterate before an `LpNumericalException` would be thrown — infeasible instances often degenerate the Cholesky step, and a certificate is a better answer than an exception — but when no certificate exists the exception is preserved unchanged: reclassifying a numerical failure without proof would be a false claim. A LIPSOL-style divergence backstop additionally stops runs whose residuals grow uncontrollably, reporting plain `IterationLimit` since divergence is a heuristic, not a certificate. Certificate rays are kept internal to the solver summary in v1; only statuses, residuals, and diagnostics are public. The specific pair `x === 1` and `x === 2` never reaches the solver at all — the two rows have identical coefficients, so exact-duplicate row hashing (see "Open decisions — resolved") catches them and fails with an `LpModelException` naming both constraints as inconsistent duplicates.
+
+## Integer and Binary variables
+
+`Integer` and `Binary` are ordinary variable categories. `model.solve()` honours their domains automatically; callers never select a solver or opt into a separate mode. Purely continuous models keep the unchanged single-solve path.
+
+Domains: a `Binary` variable ranges over `{0, 1}` intersected with its declared bounds (so `lowerBound = 1` pins it to `1`, and bounds excluding both `0` and `1` are rejected as holding no integral value). An `Integer` variable requires a finite `lowerBound` and an explicit finite `upperBound`; the declared range is tightened to the enclosed integral range (`ceil`/`floor`, absorbing floating-point fuzz within the solver tolerance), and an empty integral range is rejected at compile time.
+
+The compiler builds the relaxation once and keeps the discrete search internal. Candidate solves reuse the shared distributed cost vector and constraint matrix and differ only in the driver-local RHS. Per integral column the driver holds bounds, cost, and constraint-row coefficients, so the practical number of integral columns remains much smaller than the distributed LP dimension.
+
+Statuses stay truthful across the discrete search: a candidate is discarded as infeasible only on a Farkas certificate; `Optimal` is claimed only when every candidate is resolved and no better integral solution remains; `Unbounded` requires a dual-infeasibility certificate together with a primal-feasible integral iterate; `Infeasible` means every leaf was certificate-pruned (`InfeasibleOrUnbounded` when some candidate held only a dual certificate). Anything unresolved — the internal search limit, a candidate ending at `IterationLimit` with nothing left to branch on, or a numerical failure in a non-root candidate — degrades the result to `IterationLimit`, reporting the best integer-feasible incumbent found so far (with `NaN` objective when there is none). A numerical failure at the root propagates as `LpNumericalException`, matching the continuous path. Reported integer and binary values are exact integers, and `LpSolution.values` preserves the original domain join in the caller's units.
 
 ## Compilation contract
 

--- a/spark-lp/src/main/scala/com/github/vbmacher/spark_lp/dsl/api.scala
+++ b/spark-lp/src/main/scala/com/github/vbmacher/spark_lp/dsl/api.scala
@@ -5,20 +5,32 @@ sealed trait ObjectiveSense
 case object Minimize extends ObjectiveSense
 case object Maximize extends ObjectiveSense
 
-/** Category of a decision variable. Only [[Continuous]] is accepted in this release. */
+/** Category of a decision variable. The solver honours every category selected by the model. */
 sealed trait VariableCategory
 case object Continuous extends VariableCategory
 
-/** Reserved; rejected in this release. */
+/**
+  * Integral decision variable. Its effective domain is the integral values within its declared
+  * finite bounds.
+  */
 case object Integer extends VariableCategory
 
-/** Reserved; rejected in this release. */
+/**
+  * `{0, 1}` decision variable, intersected with any declared bounds (e.g. `lowerBound = 1` pins
+  * the variable to 1).
+  */
 case object Binary extends VariableCategory
 
 /**
   * Truthful outcome of one solve. `Infeasible` and the two unboundedness-related members are
   * claimed only when a Farkas certificate backs them (see each member); everything else that did
   * not converge is reported as [[LpStatus.IterationLimit]].
+  *
+  * For models containing [[Integer]] or [[Binary]] variables, the same members retain their
+  * truthful meaning across the discrete search: [[LpStatus.Optimal]] requires every candidate
+  * subproblem to be resolved; [[LpStatus.Infeasible]] requires every leaf to be certificate-pruned;
+  * and an unresolved subproblem degrades the result to [[LpStatus.IterationLimit]], never to a
+  * stronger claim.
   */
 sealed trait LpStatus
 

--- a/spark-lp/src/main/scala/com/github/vbmacher/spark_lp/dsl/compiler.scala
+++ b/spark-lp/src/main/scala/com/github/vbmacher/spark_lp/dsl/compiler.scala
@@ -44,7 +44,8 @@ private[dsl] object LpCompiler {
     val handle: VarSetHandle,
     val keys: RDD[(String, Seq[String])],
     val count: Long,
-    val kind: PlanKind) {
+    val kind: PlanKind,
+    val integral: Boolean) {
 
     var offset: Long = 0L
 
@@ -86,6 +87,23 @@ private[dsl] object LpCompiler {
     cost: Double,
     vector: MLVector)
 
+  /**
+    * Driver-local description of one integral (Integer/Binary) solver column, everything the
+    * discrete solver needs to retarget the equality-form RHS when the column's integral
+    * bounds are tightened. `rowCoeffs` maps emitted constraint-row indices to the column's
+    * coefficients; `boundRow` is the column's upper-bound row (`y + s = upper - lower`), which
+    * every integral column has by construction.
+    */
+  private[dsl] final case class IntColumn(
+    g: Long,
+    setIndex: Int,
+    enc: String,
+    rootLower: Double,
+    rootUpper: Double,
+    cost: Double,
+    boundRow: Int,
+    rowCoeffs: Map[Int, Double])
+
   /** Everything the solver call and the solution reconstruction need. */
   private[dsl] final class Compiled(
     val c: DVector,
@@ -98,7 +116,8 @@ private[dsl] object LpCompiler {
     val plans: IndexedSeq[SetPlan],
     val objConstant: Double,
     val senseMult: Double,
-    val userTermsAgg: RDD[((Int, String, Int), Double)])
+    val userTermsAgg: RDD[((Int, String, Int), Double)],
+    val intCols: IndexedSeq[IntColumn])
 }
 
 /**
@@ -121,17 +140,21 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
 
   def solve(): LpSolution = {
     val compiled = compile()
-    val summary = LP.solveSummary(
-      c = compiled.c,
-      AT = compiled.AT,
-      b = compiled.b,
-      tolerance = config.tolerance,
-      maxIter = config.maxIterations,
-      etaIter = config.etaIteration,
-      valueCap = config.valueCap,
-      eps = config.epsilon,
-      infeasibilityTolerance = config.infeasibilityTolerance)
-    buildSolution(compiled, summary)
+    if (compiled.intCols.isEmpty) {
+      val summary = LP.solveSummary(
+        c = compiled.c,
+        AT = compiled.AT,
+        b = compiled.b,
+        tolerance = config.tolerance,
+        maxIter = config.maxIterations,
+        etaIter = config.etaIteration,
+        valueCap = config.valueCap,
+        eps = config.epsilon,
+        infeasibilityTolerance = config.infeasibilityTolerance)
+      continuousSolution(compiled, summary)
+    } else {
+      new BranchAndBound(this, compiled, config).solve()
+    }
   }
 
   // -------------------------------------------------------------------------------------------
@@ -426,6 +449,42 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
     cVec.count()
     AT.count()
 
+    // --- driver-local layout of integral columns for the discrete solver
+    val intCols: IndexedSeq[IntColumn] = {
+      val intPlans = plans.filter(p => p.integral && p.columns > 0)
+      if (intPlans.isEmpty) IndexedSeq.empty
+      else {
+        val boundRowBase = boundBlocks.map(bb => bb.plan.handle.setIndex -> bb.rowBase).toMap
+        val partial = intPlans.flatMap { p =>
+          val si = p.handle.setIndex
+          val (shift, upper) = p.kind match {
+            case ShiftedKind(s, Some(u)) => (s, u)
+            case other =>
+              throw new IllegalStateException(s"integral plan of '${p.handle.name}' has unexpected kind $other")
+          }
+          val off = p.offset
+          val rowBase = boundRowBase(si)
+          // constraint-row coefficients per key; merged/presolved rows are absent from rowRemap
+          val coeffRows: Map[String, Map[Int, Double]] = solverTerms
+            .filter { case ((s, _, _), _) => s == si }
+            .flatMap { case ((_, enc, r), coeff) => rowRemap.value.get(r).map(fr => (enc, (fr, coeff))) }
+            .collect()
+            .groupBy(_._1)
+            .map { case (enc, entries) => enc -> entries.map(_._2).toMap }
+          p.sortedKeys.collect().map { case (enc, (i, _)) =>
+            IntColumn(off + i, si, enc, shift, upper, 0.0, rowBase + i.toInt,
+              coeffRows.getOrElse(enc, Map.empty))
+          }
+        }
+        val gSet = sc.broadcast(partial.map(_.g).toSet)
+        val costByG = sortedCols
+          .filter { case (g, _) => gSet.value.contains(g) }
+          .map { case (g, colData) => (g, colData.cost) }
+          .collect().toMap
+        partial.map(ic => ic.copy(cost = costByG(ic.g))).sortBy(_.g).toIndexedSeq
+      }
+    }
+
     new Compiled(
       c = cVec,
       AT = AT,
@@ -437,7 +496,8 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
       plans = plans,
       objConstant = objConstant,
       senseMult = senseMult,
-      userTermsAgg = userTermsAgg)
+      userTermsAgg = userTermsAgg,
+      intCols = intCols)
   }
 
   // -------------------------------------------------------------------------------------------
@@ -446,20 +506,25 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
 
   private def buildPlan(handle: VarSetHandle): SetPlan = {
     val where = s"variable '${handle.name}'"
-    if (handle.category != Continuous) {
-      fail(s"$where: category ${handle.category} is not supported in this release; only Continuous is accepted")
-    }
-    val lb = handle.lowerBound
-    if (lb.isNaN || lb == Double.PositiveInfinity) {
-      fail(s"$where: lower bound must not be NaN or +inf (got $lb); Double.NegativeInfinity means a free variable")
+    val declaredLb = handle.lowerBound
+    if (declaredLb.isNaN || declaredLb == Double.PositiveInfinity) {
+      fail(s"$where: lower bound must not be NaN or +inf (got $declaredLb); Double.NegativeInfinity means a free variable")
     }
     handle.upperBound.foreach { ub =>
       if (ub.isNaN || ub.isInfinite) {
         fail(s"$where: upper bound must be finite when defined (got $ub); unbounded is expressed as None")
       }
-      if (lb == Double.NegativeInfinity) {
-        fail(s"$where: a finite upper bound combined with a -inf lower bound is not supported in this release")
-      }
+    }
+
+    val (lb, upperOpt, integral) = handle.category match {
+      case Continuous => (declaredLb, handle.upperBound, false)
+      case category => integralBounds(handle, category, where)
+    }
+
+    if (upperOpt.isDefined && lb == Double.NegativeInfinity) {
+      fail(s"$where: a finite upper bound combined with a -inf lower bound is not supported in this release")
+    }
+    upperOpt.foreach { ub =>
       if (lb > ub) {
         fail(s"$where: lowerBound ($lb) > upperBound ($ub)")
       }
@@ -483,10 +548,42 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
     }
 
     val kind =
-      if (handle.upperBound.contains(lb)) FixedKind(lb)
+      if (upperOpt.contains(lb)) FixedKind(lb)
       else if (lb == Double.NegativeInfinity) SplitKind
-      else ShiftedKind(lb, handle.upperBound)
-    new SetPlan(handle, keys, count, kind)
+      else ShiftedKind(lb, upperOpt)
+    new SetPlan(handle, keys, count, kind, integral)
+  }
+
+  /**
+    * Effective integral bounds of an [[Integer]] or [[Binary]] variable: the declared bounds
+    * (intersected with `{0, 1}` for Binary) tightened to the enclosed integral range. The result
+    * always has finite bounds, so every integral column owns an upper-bound row that the solver can
+    * retarget while exploring the discrete model.
+    */
+  private def integralBounds(
+    handle: VarSetHandle,
+    category: VariableCategory,
+    where: String): (Double, Option[Double], Boolean) = {
+
+    val (lo, hi) = category match {
+      case Binary =>
+        (math.max(handle.lowerBound, 0.0), math.min(handle.upperBound.getOrElse(1.0), 1.0))
+      case _ =>
+        if (handle.lowerBound == Double.NegativeInfinity) {
+          fail(s"$where: an Integer variable requires a finite lower bound")
+        }
+        val ub = handle.upperBound.getOrElse(
+          fail(s"$where: an Integer variable requires a finite upper bound; declare upperBound explicitly"))
+        (handle.lowerBound, ub)
+    }
+    val tol = BranchAndBound.IntegralityTolerance
+    val lower = math.ceil(lo - tol)
+    val upper = math.floor(hi + tol)
+    if (lower > upper) {
+      val detail = if (category == Binary) " after intersecting the declared bounds with the Binary domain {0, 1}" else ""
+      fail(s"$where: no integral values within bounds [$lo, $hi]$detail")
+    }
+    (lower, Some(upper), true)
   }
 
   // -------------------------------------------------------------------------------------------
@@ -755,23 +852,66 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
   // Solution reconstruction
   // -------------------------------------------------------------------------------------------
 
-  private def buildSolution(compiled: Compiled, summary: LP.SolveSummary): LpSolution = {
+  /**
+    * Maps a continuous solver summary to the public status/objective pair and reconstructs the
+    * solution — the unchanged single-solve path used whenever the model has no integral columns.
+    */
+  private def continuousSolution(compiled: Compiled, summary: LP.SolveSummary): LpSolution = {
+    val status: LpStatus = summary.termination match {
+      case LP.Termination.Converged => LpStatus.Optimal
+      case LP.Termination.IterationLimit => LpStatus.IterationLimit
+      case LP.Termination.PrimalInfeasible => LpStatus.Infeasible
+      case LP.Termination.DualInfeasible =>
+        // a dual-infeasibility ray proves unboundedness only together with a primal-feasible point
+        if (summary.primalResidual < config.tolerance) LpStatus.Unbounded
+        else LpStatus.InfeasibleOrUnbounded
+    }
+    val objectiveValue = status match {
+      case LpStatus.Infeasible | LpStatus.InfeasibleOrUnbounded => Double.NaN
+      // the solver minimizes, so an unbounded objective diverges to -inf in solver form
+      case LpStatus.Unbounded => compiled.senseMult * Double.NegativeInfinity
+      case _ => compiled.senseMult * summary.objectiveValue + compiled.objConstant
+    }
+    buildSolution(compiled, summary.x, status, objectiveValue, summary.iterations,
+      LpResiduals(summary.primalResidual, summary.dualResidual, summary.dualityGap), Map.empty)
+  }
+
+  /**
+    * Reconstructs user-facing values and diagnostics from a solver iterate. `integerOverrides`
+    * carries exact user-unit values (already rounded to integers) for integral solver columns,
+    * keyed by the global column index; an empty map reproduces the plain continuous
+    * reconstruction.
+    */
+  private[dsl] def buildSolution(
+    compiled: Compiled,
+    x: DVector,
+    status: LpStatus,
+    objectiveValue: Double,
+    iterations: Int,
+    residuals: LpResiduals,
+    integerOverrides: Map[Long, Double]): LpSolution = {
+
     // per-column primal values, aligned with the compiled column order
-    val xValues: RDD[(ColData, Double)] = compiled.sortedCols.zipPartitions(summary.x) { (colsIt, xIt) =>
+    val overrides = sc.broadcast(integerOverrides)
+    val xValues: RDD[(Long, ColData, Double)] = compiled.sortedCols.zipPartitions(x) { (colsIt, xIt) =>
       if (!xIt.hasNext) Iterator.empty
       else {
         val values = xIt.next().values
-        colsIt.zipWithIndex.map { case ((_, colData), i) => (colData, values(i)) }
+        colsIt.zipWithIndex.map { case ((g, colData), i) => (g, colData, values(i)) }
       }
     }
 
     // undo bound shifts and free-variable splits; drop slacks
-    val varValues = xValues.flatMap { case (colData, v) =>
-      colData.kind match {
-        case 0 => Some(((colData.setIndex, colData.enc), colData.shift + v))
-        case 1 => Some(((colData.setIndex, colData.enc), v))
-        case 2 => Some(((colData.setIndex, colData.enc), -v))
-        case _ => None
+    val varValues = xValues.flatMap { case (g, colData, v) =>
+      overrides.value.get(g) match {
+        case Some(exact) => Some(((colData.setIndex, colData.enc), exact))
+        case None =>
+          colData.kind match {
+            case 0 => Some(((colData.setIndex, colData.enc), colData.shift + v))
+            case 1 => Some(((colData.setIndex, colData.enc), v))
+            case 2 => Some(((colData.setIndex, colData.enc), -v))
+            case _ => None
+          }
       }
     }.reduceByKey(_ + _)
 
@@ -814,27 +954,11 @@ private[dsl] final class LpCompiler(problem: LpProblem, config: SolveConfig) {
     }
     val constraintsDf = spark.createDataFrame(sc.parallelize(rows, 1), schema)
 
-    val status: LpStatus = summary.termination match {
-      case LP.Termination.Converged => LpStatus.Optimal
-      case LP.Termination.IterationLimit => LpStatus.IterationLimit
-      case LP.Termination.PrimalInfeasible => LpStatus.Infeasible
-      case LP.Termination.DualInfeasible =>
-        // a dual-infeasibility ray proves unboundedness only together with a primal-feasible point
-        if (summary.primalResidual < config.tolerance) LpStatus.Unbounded
-        else LpStatus.InfeasibleOrUnbounded
-    }
-    val objectiveValue = status match {
-      case LpStatus.Infeasible | LpStatus.InfeasibleOrUnbounded => Double.NaN
-      // the solver minimizes, so an unbounded objective diverges to -inf in solver form
-      case LpStatus.Unbounded => compiled.senseMult * Double.NegativeInfinity
-      case _ => compiled.senseMult * summary.objectiveValue + compiled.objConstant
-    }
-
     new LpSolution(
       status = status,
       objectiveValue = objectiveValue,
-      iterations = summary.iterations,
-      residuals = LpResiduals(summary.primalResidual, summary.dualResidual, summary.dualityGap),
+      iterations = iterations,
+      residuals = residuals,
       constraints = constraintsDf,
       problem = problem,
       userValues = userValues)

--- a/spark-lp/src/main/scala/com/github/vbmacher/spark_lp/dsl/mip.scala
+++ b/spark-lp/src/main/scala/com/github/vbmacher/spark_lp/dsl/mip.scala
@@ -1,0 +1,329 @@
+package com.github.vbmacher.spark_lp.dsl
+
+import com.github.vbmacher.spark_lp.LP
+import com.github.vbmacher.spark_lp.dsl.LpCompiler.Compiled
+import com.github.vbmacher.spark_lp.vectors.DVector
+import org.apache.spark.mllib.linalg.DenseVector
+import org.apache.spark.sql.SparkSession
+
+import scala.collection.mutable
+
+/**
+  * Branch-and-bound search over the integral columns of a compiled model.
+  *
+  * The model is compiled exactly once: every node reuses the shared distributed cost vector and
+  * constraint matrix and differs only in the driver-local RHS. Tightening an integral column to
+  * `[L, U]` folds into the equality form as an extra lower-bound shift (`b(r) -= a_rj * (L - L0)`
+  * for every constraint row the column touches) plus a new RHS for the column's upper-bound row
+  * (`U - L`). Nodes are explored best-first (smallest relaxation bound first) with
+  * most-fractional branching.
+  *
+  * Status truthfulness:
+  *   - a node is discarded as infeasible only on a Farkas certificate ([[LP.Termination.PrimalInfeasible]]);
+  *   - `Optimal` is claimed only when the tree is exhausted, every node was resolved exactly, and
+  *     no better solution can exist beyond `gapTolerance`;
+  *   - `Unbounded` is claimed only for a node with a dual-infeasibility certificate whose iterate
+  *     is primal-feasible with integral values;
+  *   - anything unresolved (node budget, an unresolved node relaxation, a numerical failure in a
+  *     non-root node) degrades the final status to `IterationLimit`; a numerical failure at the
+  *     root propagates, matching the continuous path.
+  */
+private[dsl] final class BranchAndBound(
+  compiler: LpCompiler,
+  compiled: Compiled,
+  config: SolveConfig)(implicit spark: SparkSession) {
+
+  import BranchAndBound._
+
+  private val intCols = compiled.intCols
+  private val n = intCols.size
+  private val rootLower: Array[Double] = intCols.map(_.rootLower).toArray
+  private val intGSet = spark.sparkContext.broadcast(intCols.map(_.g).toSet)
+
+  private var incumbent: Option[Candidate] = None
+  private var unboundedProof: Option[Candidate] = None
+  private var rootX: DVector = _
+  private var rootSummary: LP.SolveSummary = _
+  private var sawUnboundedNode = false
+  // false once any node is left unresolved: Optimal / Infeasible can no longer be claimed
+  private var exact = true
+  private var solvedNodes = 0
+  private var totalIterations = 0
+
+  def solve(): LpSolution = {
+    val open = mutable.PriorityQueue.empty[Node](Ordering.by[Node, Double](_.bound).reverse)
+    open.enqueue(Node(
+      lower = intCols.map(_.rootLower).toArray,
+      upper = intCols.map(_.rootUpper).toArray,
+      bound = Double.NegativeInfinity))
+
+    while (open.nonEmpty && unboundedProof.isEmpty && solvedNodes < DefaultMaxNodes) {
+      val node = open.dequeue()
+      if (!prunable(node.bound)) {
+        processNode(node, open)
+      }
+    }
+
+    // outstanding nodes below the incumbent bound do not compromise optimality
+    val searchComplete = unboundedProof.isEmpty && open.forall(node => prunable(node.bound))
+    assemble(searchComplete)
+  }
+
+  private def prunable(bound: Double): Boolean = incumbent.exists { inc =>
+    bound >= inc.objMin - GapTolerance * math.max(1.0, math.abs(inc.objMin))
+  }
+
+  private def processNode(node: Node, open: mutable.PriorityQueue[Node]): Unit = {
+    val isRoot = solvedNodes == 0
+    val summary =
+      try {
+        LP.solveSummary(
+          c = compiled.c,
+          AT = compiled.AT,
+          b = nodeRhs(node),
+          tolerance = config.tolerance,
+          maxIter = config.maxIterations,
+          etaIter = config.etaIteration,
+          valueCap = config.valueCap,
+          eps = config.epsilon,
+          infeasibilityTolerance = config.infeasibilityTolerance)
+      } catch {
+        case e: LpNumericalException =>
+          if (isRoot) throw e
+          exact = false // the node stays unresolved; a better solution may hide in it
+          return
+      }
+    solvedNodes += 1
+    totalIterations += summary.iterations
+    if (isRoot) {
+      rootX = summary.x
+      rootSummary = summary
+    }
+
+    // full solver-form objective of the node iterate, comparable across nodes
+    val objMin = summary.objectiveValue + shiftCost(node)
+
+    summary.termination match {
+      case LP.Termination.Converged =>
+        if (!prunable(objMin)) {
+          val vals = integerValues(node, summary.x)
+          mostFractional(node, vals) match {
+            case Some((j, v)) =>
+              branch(node, j, v, objMin, open)
+            case None =>
+              roundedValues(node, vals) match {
+                case Some(rounded) if incumbent.forall(objMin < _.objMin) =>
+                  incumbent.foreach(old => release(old.x))
+                  incumbent = Some(Candidate(objMin, summary.x, rounded, summary))
+                case Some(_) => () // integral but not better; node is exhausted
+                case None => exact = false // iterate neither fractional nor cleanly integral
+              }
+          }
+        }
+      case LP.Termination.PrimalInfeasible =>
+        () // Farkas certificate: the node provably holds no feasible point
+      case LP.Termination.DualInfeasible =>
+        sawUnboundedNode = true
+        val vals = integerValues(node, summary.x)
+        if (summary.primalResidual < config.tolerance) {
+          roundedValues(node, vals) match {
+            case Some(rounded) =>
+              // primal-feasible integral iterate + dual-infeasibility certificate: unbounded
+              unboundedProof = Some(Candidate(Double.NegativeInfinity, summary.x, rounded, summary))
+            case None => branchOrGiveUp(node, vals, open)
+          }
+        } else {
+          branchOrGiveUp(node, vals, open)
+        }
+      case LP.Termination.IterationLimit =>
+        branchOrGiveUp(node, integerValues(node, summary.x), open)
+    }
+
+    if ((summary.x ne rootX) && !incumbent.exists(_.x eq summary.x) && !unboundedProof.exists(_.x eq summary.x)) {
+      release(summary.x)
+    }
+  }
+
+  /** Driver-local RHS of the node: root RHS with the tightened integral bounds folded in. */
+  private def nodeRhs(node: Node): DenseVector = {
+    val b = compiled.b.values.clone()
+    var j = 0
+    while (j < n) {
+      val col = intCols(j)
+      val deltaL = node.lower(j) - rootLower(j)
+      if (deltaL != 0.0) {
+        col.rowCoeffs.foreach { case (r, a) => b(r) -= a * deltaL }
+      }
+      b(col.boundRow) = node.upper(j) - node.lower(j)
+      j += 1
+    }
+    new DenseVector(b)
+  }
+
+  /** Solver-form objective contribution of the node's extra lower-bound shifts. */
+  private def shiftCost(node: Node): Double = {
+    var acc = 0.0
+    var j = 0
+    while (j < n) {
+      acc += intCols(j).cost * (node.lower(j) - rootLower(j))
+      j += 1
+    }
+    acc
+  }
+
+  /** Solver values of the integral columns, keyed by global column index (one collect per node). */
+  private def integerValues(node: Node, x: DVector): Map[Long, Double] = {
+    val gSet = intGSet
+    compiled.sortedCols.zipPartitions(x) { (colsIt, xIt) =>
+      if (!xIt.hasNext) Iterator.empty
+      else {
+        val values = xIt.next().values
+        colsIt.zipWithIndex.collect { case (((g, _), i)) if gSet.value.contains(g) => (g, values(i)) }
+      }
+    }.collect().toMap
+  }
+
+  /** User-unit value of integral column `j` at the node, clamped into the node's bounds. */
+  private def userValue(node: Node, vals: Map[Long, Double], j: Int): Double = {
+    val raw = node.lower(j) + vals(intCols(j).g)
+    math.min(math.max(raw, node.lower(j)), node.upper(j))
+  }
+
+  /** The unfixed column whose value is farthest from an integer, if any exceeds the tolerance. */
+  private def mostFractional(node: Node, vals: Map[Long, Double]): Option[(Int, Double)] = {
+    var best = -1
+    var bestFrac = IntegralityTolerance
+    var bestV = 0.0
+    var j = 0
+    while (j < n) {
+      if (node.lower(j) < node.upper(j)) {
+        val v = userValue(node, vals, j)
+        val frac = math.abs(v - math.rint(v))
+        if (frac > bestFrac) {
+          best = j
+          bestFrac = frac
+          bestV = v
+        }
+      }
+      j += 1
+    }
+    if (best >= 0) Some((best, bestV)) else None
+  }
+
+  /**
+    * Exact user-unit integers of the node iterate, or `None` when any column is not integral
+    * within the tolerance. Keys are global column indices, matching `buildSolution` overrides.
+    */
+  private def roundedValues(node: Node, vals: Map[Long, Double]): Option[Map[Long, Double]] = {
+    val out = new Array[Double](n)
+    var j = 0
+    while (j < n) {
+      val raw = node.lower(j) + vals(intCols(j).g)
+      val r = math.rint(raw)
+      if (math.abs(raw - r) > IntegralityTolerance || r < node.lower(j) || r > node.upper(j)) {
+        return None
+      }
+      out(j) = r
+      j += 1
+    }
+    Some(intCols.indices.map(j => intCols(j).g -> out(j)).toMap)
+  }
+
+  /** Splits the node on column `j` around the fractional value `v` (both children are non-empty). */
+  private def branch(node: Node, j: Int, v: Double, childBound: Double, open: mutable.PriorityQueue[Node]): Unit = {
+    val upper = node.upper.clone()
+    upper(j) = math.floor(v)
+    val lower = node.lower.clone()
+    lower(j) = math.ceil(v)
+    open.enqueue(Node(node.lower, upper, childBound))
+    open.enqueue(Node(lower, node.upper, childBound))
+  }
+
+  /**
+    * Progress on a node whose relaxation was not resolved (iteration limit, or a
+    * dual-infeasibility certificate without a usable primal point): branch on a fractional column,
+    * fall back to a midpoint split of the first unfixed column, or — with everything fixed —
+    * leave the node unresolved. Children inherit the parent's bound: the iterate proves nothing.
+    */
+  private def branchOrGiveUp(node: Node, vals: Map[Long, Double], open: mutable.PriorityQueue[Node]): Unit = {
+    mostFractional(node, vals) match {
+      case Some((j, v)) => branch(node, j, v, node.bound, open)
+      case None =>
+        val j = node.lower.indices.find(j => node.lower(j) < node.upper(j))
+        j match {
+          case Some(k) =>
+            val mid = math.floor((node.lower(k) + node.upper(k)) / 2.0)
+            branch(node, k, mid + 0.5, node.bound, open)
+          case None => exact = false // fully fixed and still unresolved
+        }
+    }
+  }
+
+  private def release(x: DVector): Unit = {
+    if (x ne rootX) x.unpersist(blocking = false)
+  }
+
+  private def assemble(searchComplete: Boolean): LpSolution = {
+    unboundedProof match {
+      case Some(proof) =>
+        compiler.buildSolution(
+          compiled,
+          x = proof.x,
+          status = LpStatus.Unbounded,
+          // the solver minimizes, so an unbounded objective diverges to -inf in solver form
+          objectiveValue = compiled.senseMult * Double.NegativeInfinity,
+          iterations = totalIterations,
+          residuals = residualsOf(proof.summary),
+          integerOverrides = proof.values)
+      case None =>
+        incumbent match {
+          case Some(inc) =>
+            val status = if (searchComplete && exact) LpStatus.Optimal else LpStatus.IterationLimit
+            compiler.buildSolution(
+              compiled,
+              x = inc.x,
+              status = status,
+              objectiveValue = compiled.senseMult * inc.objMin + compiled.objConstant,
+              iterations = totalIterations,
+              residuals = residualsOf(inc.summary),
+              integerOverrides = inc.values)
+          case None =>
+            val status =
+              if (searchComplete && exact) {
+                if (sawUnboundedNode) LpStatus.InfeasibleOrUnbounded else LpStatus.Infeasible
+              } else {
+                LpStatus.IterationLimit
+              }
+            // no integer-feasible point exists to report; expose the root relaxation iterate
+            compiler.buildSolution(
+              compiled,
+              x = rootX,
+              status = status,
+              objectiveValue = Double.NaN,
+              iterations = totalIterations,
+              residuals = residualsOf(rootSummary),
+              integerOverrides = Map.empty)
+        }
+    }
+  }
+
+  private def residualsOf(summary: LP.SolveSummary): LpResiduals =
+    LpResiduals(summary.primalResidual, summary.dualResidual, summary.dualityGap)
+}
+
+private[dsl] object BranchAndBound {
+
+  private[dsl] val DefaultMaxNodes = 1000
+  private[dsl] val IntegralityTolerance = 1e-6
+  private[dsl] val GapTolerance = 1e-9
+
+  /** One open subproblem: integral bounds per column (aligned with `intCols`) and its best bound. */
+  private final case class Node(lower: Array[Double], upper: Array[Double], bound: Double)
+
+  /** A retained iterate: solver-form objective, iterate, exact integer overrides and diagnostics. */
+  private final case class Candidate(
+    objMin: Double,
+    x: DVector,
+    values: Map[Long, Double],
+    summary: LP.SolveSummary)
+}

--- a/spark-lp/src/test/scala/com/github/vbmacher/spark_lp/dsl/LpDslMipSuite.scala
+++ b/spark-lp/src/test/scala/com/github/vbmacher/spark_lp/dsl/LpDslMipSuite.scala
@@ -1,0 +1,128 @@
+package com.github.vbmacher.spark_lp.dsl
+
+import com.github.vbmacher.spark_lp.TestingUtils._
+import com.github.vbmacher.spark_lp.dsl.implicits._
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Integer/Binary variables solve through the same public API as continuous variables. */
+class LpDslMipSuite extends AnyFunSuite with DataFrameSuiteBase {
+
+  test("Integer and Binary variables use the standard solve path") {
+    implicit val ss: SparkSession = spark
+    for (category <- Seq(Integer, Binary)) {
+      val model = LpProblem("cat", Minimize)
+      val x = model.variable("x", upperBound = Some(1.0), category = category)
+      model += lpSum(x)
+      model += (x >= 1.0).named("floor")
+      val solution = model.solve()
+      assert(solution.status == LpStatus.Optimal)
+      assert(solution.value(x) == 1.0)
+    }
+  }
+
+  test("bounded Integer variables: max x + y with 2x + 2y <= 3 is 1, not the relaxation's 1.5") {
+    implicit val ss: SparkSession = spark
+    val model = LpProblem("boundedInt", Maximize)
+    val x = model.variable("x", upperBound = Some(5.0), category = Integer)
+    val y = model.variable("y", upperBound = Some(5.0), category = Integer)
+    model += x + y
+    model += (2.0 * x + 2.0 * y <= 3.0).named("cap")
+
+    val solution = model.solve()
+    assert(solution.status == LpStatus.Optimal)
+    assert(solution.objectiveValue ~== 1.0 absTol 1e-6)
+    val (vx, vy) = (solution.value(x), solution.value(y))
+    assert(vx == math.rint(vx) && vy == math.rint(vy), s"values must be integral, got ($vx, $vy)")
+    assert(vx + vy == 1.0)
+  }
+
+  test("binary knapsack over a DataFrame domain picks the optimal subset") {
+    implicit val ss: SparkSession = spark
+    val ssLocal = spark
+    import ssLocal.implicits._
+    val items = Seq(("a", 10.0, 6.0), ("b", 7.0, 5.0), ("c", 6.0, 5.0)).toDF("item", "value", "weight")
+
+    val model = LpProblem("knapsack", Maximize)
+    val pick = model.variables("pick", items, $"item", category = Binary)
+    model += lpSum(pick * $"value")
+    model += (lpSum(pick * $"weight") <= 10.0).named("capacity")
+
+    val solution = model.solve()
+    assert(solution.status == LpStatus.Optimal)
+    // LP relaxation packs 'a' plus a fraction of 'b' (15.6); the integer optimum is {b, c} = 13
+    assert(solution.objectiveValue ~== 13.0 absTol 1e-6)
+
+    val values = solution.values(pick)
+    assert(values.columns.toSeq == Seq("item", "value", "weight", "lp_variable", "lp_value"))
+    val byItem = values.select("item", "lp_value").collect()
+      .map(r => r.getString(0) -> r.getDouble(1)).toMap
+    assert(byItem == Map("a" -> 0.0, "b" -> 1.0, "c" -> 1.0))
+  }
+
+  test("mixed model: Integer x and continuous y keep integrality only where declared") {
+    implicit val ss: SparkSession = spark
+    val model = LpProblem("mixed", Maximize)
+    val x = model.variable("x", upperBound = Some(10.0), category = Integer)
+    val y = model.variable("y", upperBound = Some(4.5))
+    model += 2.0 * x + y
+    model += (x + y <= 7.3).named("budget")
+
+    val solution = model.solve()
+    assert(solution.status == LpStatus.Optimal)
+    assert(solution.objectiveValue ~== 14.3 absTol 1e-5)
+    assert(solution.value(x) == 7.0, "the Integer variable must be exactly integral")
+    assert(solution.value(y) ~== 0.3 absTol 1e-5)
+  }
+
+  test("integer-infeasible model is truthfully Infeasible: 10 <= 3x <= 11 with Integer x") {
+    implicit val ss: SparkSession = spark
+    val model = LpProblem("intInfeasible", Minimize)
+    val x = model.variable("x", upperBound = Some(10.0), category = Integer)
+    model += lpSum(x)
+    model += (3.0 * x >= 10.0).named("lo")
+    model += (3.0 * x <= 11.0).named("hi")
+
+    // the relaxation is feasible (10/3 <= x <= 11/3) but holds no integer;
+    // both branches (x <= 3, x >= 4) carry Farkas certificates
+    val solution = model.solve()
+    assert(solution.status == LpStatus.Infeasible)
+    assert(solution.objectiveValue.isNaN)
+  }
+
+  test("Binary bounds intersect {0, 1}: lowerBound = 1 pins the variable to exactly 1") {
+    implicit val ss: SparkSession = spark
+    val model = LpProblem("pinnedBinary", Minimize)
+    val x = model.variable("x", lowerBound = 1.0, category = Binary)
+    val y = model.variable("y", upperBound = Some(10.0))
+    model += x + y
+    model += (y - x >= 0.0).named("chain")
+
+    val solution = model.solve()
+    assert(solution.status == LpStatus.Optimal)
+    assert(solution.objectiveValue ~== 2.0 absTol 1e-6)
+    assert(solution.value(x) == 1.0)
+    assert(solution.value(y) ~== 1.0 absTol 1e-5)
+  }
+
+  test("Integer without an explicit finite upper bound is rejected") {
+    implicit val ss: SparkSession = spark
+    val model = LpProblem("noUb", Minimize)
+    val x = model.variable("x", category = Integer)
+    model += lpSum(x)
+    model += (x >= 1.0).named("floor")
+    val e = intercept[LpModelException](model.solve())
+    assert(e.getMessage.contains("finite upper bound"))
+  }
+
+  test("Binary whose declared bounds exclude {0, 1} entirely is rejected") {
+    implicit val ss: SparkSession = spark
+    val model = LpProblem("emptyBinary", Minimize)
+    val x = model.variable("x", lowerBound = 2.0, category = Binary)
+    model += lpSum(x)
+    model += (x >= 0.0).named("floor")
+    val e = intercept[LpModelException](model.solve())
+    assert(e.getMessage.contains("no integral values"))
+  }
+}

--- a/spark-lp/src/test/scala/com/github/vbmacher/spark_lp/dsl/LpDslTransformSuite.scala
+++ b/spark-lp/src/test/scala/com/github/vbmacher/spark_lp/dsl/LpDslTransformSuite.scala
@@ -161,16 +161,4 @@ class LpDslTransformSuite extends AnyFunSuite with DataFrameSuiteBase {
     assert(failing(0.0, Some(Double.NaN)).getMessage.contains("upper bound"))
     assert(failing(0.0, Some(Double.PositiveInfinity)).getMessage.contains("upper bound"))
   }
-
-  test("Integer and Binary categories are rejected in this release") {
-    implicit val ss: SparkSession = spark
-    for (category <- Seq(Integer, Binary)) {
-      val model = LpProblem("cat", Minimize)
-      val x = model.variable("x", category = category)
-      model += lpSum(x)
-      model += (x >= 1.0).named("floor")
-      val e = intercept[LpModelException](model.solve())
-      assert(e.getMessage.contains("Continuous"))
-    }
-  }
 }


### PR DESCRIPTION
## Summary

- Add first-class `Integer` and `Binary` variable categories to the DataFrame/Dataset LP DSL; callers use the standard `model.solve()` path.
- Compile integral domains to the existing solver representation and keep the discrete search internal, including exact reconstruction of reported integral values.
- Preserve certificate-backed infeasibility and unboundedness semantics across integral candidate solves.
- Document finite integral-bound validation and cover integer, binary, mixed, knapsack, and integer-infeasible models.

## QA

- `sbt 'spark-lpSpark_3_02_12/testOnly com.github.vbmacher.spark_lp.dsl.LpDslMipSuite'` (8 tests passed)
- `git diff --check`

## Notes

- `Binary` is constrained to `{0, 1}` intersected with declared bounds.
- `Integer` variables currently require explicit finite bounds.